### PR TITLE
Include the actual jQuery source asset.

### DIFF
--- a/src/main/docs/guide/addJavascriptAsset.adoc
+++ b/src/main/docs/guide/addJavascriptAsset.adoc
@@ -12,7 +12,7 @@ Edit `grails-app/views/home/index.gsp`, add the following snippet in the _head_ 
 [source, xml]
 .grails-app/views/home/index.gsp
 ----
-include::{sourceDir}/grails-app/views/home/index.gsp[indent=0,lines="11..17"]
+include::{sourceDir}/grails-app/views/home/index.gsp[indent=0,lines="10..16"]
 ----
 
 Refresh the page, and open your browser's developer console. You should see the string `jQuery 3.1.1 loaded!` in the console logs.


### PR DESCRIPTION
The jquery...js is not included by the previous listing, but without that, the snippet will not work. It probably just slipped out with a deleted line from above.