### PR TITLE
Align controller creation command on the domain class one

### DIFF
--- a/src/main/docs/guide/controllers.adoc
+++ b/src/main/docs/guide/controllers.adoc
@@ -6,7 +6,7 @@ Following the convention over configuration principle, Grails will configure any
 
 [source, bash]
 ----
-$ ./grailsw create-controller org.grails.guides.Home
+$ ./grailsw create-controller Home
 
 | Created grails-app/controllers/org/grails/guides/HomeController.groovy
 | Created src/test/groovy/org/grails/guides/HomeControllerSpec.groovy


### PR DESCRIPTION
In the domain class creation we do not specify the class full qualified name. Doing the same for the Controller as the discrepancy might confuse people.