### PR TITLE
Add packages to import statements

### DIFF
--- a/src/main/docs/guide/gsp.adoc
+++ b/src/main/docs/guide/gsp.adoc
@@ -7,7 +7,7 @@ Edit `grails-app/views/home/index.gsp`
 [source,xml]
 .grails-app/views/home/index.gsp
 ----
-<%@ page import="Vehicle" %>
+<%@ page import="org.grails.guides.Vehicle" %>
 <html>
 <head>
     <meta name="layout" content="public"/>

--- a/src/main/docs/guide/gspIteration.adoc
+++ b/src/main/docs/guide/gspIteration.adoc
@@ -5,7 +5,7 @@ There are GSP tags for iteration as well - a very useful one is `<g:each>`. Let'
 [source,xml]
 .grails-app/views/home/index.gsp
 ----
-<%@ page import="Vehicle" %> //<1>
+<%@ page import="org.grails.guides.Vehicle" %> //<1>
 <html>
 <!-- ... -->
         <p>There are ${vehicleTotal} vehicles in the database.</p>


### PR DESCRIPTION
An import statement that omits packages is causing compilation errors and should be corrected, unless they were omitted intentionally to challenge the learner.