### PR TITLE
Correct source file references

### DIFF
--- a/src/main/docs/guide/services.adoc
+++ b/src/main/docs/guide/services.adoc
@@ -53,7 +53,7 @@ Edit `grails-app/controllers/org/grails/guides/VehicleController.groovy` (the sc
 [source,groovy]
 .grails-app/controllers/org/grails/guides/VehicleController.groovy
 ----
-include::{sourceDir}/grails-app/controllers/org/grails/guides/scaffolding/VehicleController.groovy[indent=0,lines="6..11"]
+include::{sourceDir}/grails-app/controllers/org/grails/guides/VehicleController.groovy[indent=0,lines="11..16"]
 ----
 <1> By simply defining a property in our controller with the same name as our service class, Grails will inject a reference to the service for us.
 
@@ -63,7 +63,7 @@ Now (still editing `VehicleController.groovy`), modify the `show` action as seen
 [source,groovy]
 .grails-app/controllers/org/grails/guides/VehicleController.groovy
 ----
-include::{sourceDir}/grails-app/controllers/org/grails/guides/VehicleController.groovy[indent=0,lines="18..20"]
+include::{sourceDir}/grails-app/controllers/org/grails/guides/VehicleController.groovy[indent=0,lines="22..24"]
 ----
 
 We've added new property to the `model`, called `estimatedValue`. The value of this property is the result of calling our service method, `getEstimate`, to which we pass the `vehicle` property we are about to render.


### PR DESCRIPTION
It appears that the source code files have changed since this section was last edited. Consequently, the included source snippets are wrong and the end of this section does not make sense.
http://guides.grails.org/creating-your-first-grails-app/guide/index.html#services
Also, one of the include directives refers to a scaffold controller which does not declare a service.
This commit fixes these problem, at least until the groovy source files are inadvertently changed again!