### PR TITLE
Note on using grails list-profiles

### DIFF
--- a/src/main/docs/guide/applicationProfile.adoc
+++ b/src/main/docs/guide/applicationProfile.adoc
@@ -1,7 +1,9 @@
 
 You can optionally specify a http://docs.grails.org/latest/guide/profiles.html[Profile] for your Grails app. Profiles are available for many common application types, including `rest-api`, `angular`, `react`, and others, and you can even create your own.
 
-To view of a list of what profiles are available, use the http://docs.grails.org/latest/ref/Command%20Line/list-profiles.html[`list-profiles`] command.  *Please note this command must be run from outside of the directory for the Grails project you created in the last step.*
+To view of a list of what profiles are available, use the http://docs.grails.org/latest/ref/Command%20Line/list-profiles.html[`list-profiles`] command.
+
+*Please note this command `grails list-profiles` must be run from outside of the directory for the Grails project you created in the last step.*
 
 [source, bash]
 ----

--- a/src/main/docs/guide/applicationProfile.adoc
+++ b/src/main/docs/guide/applicationProfile.adoc
@@ -1,7 +1,7 @@
 
 You can optionally specify a http://docs.grails.org/latest/guide/profiles.html[Profile] for your Grails app. Profiles are available for many common application types, including `rest-api`, `angular`, `react`, and others, and you can even create your own.
 
-To view of a list of what profiles are available, use the http://docs.grails.org/latest/ref/Command%20Line/list-profiles.html[`list-profiles`] command.
+To view of a list of what profiles are available, use the http://docs.grails.org/latest/ref/Command%20Line/list-profiles.html[`list-profiles`] command.  *Please note this command must be run from outside of the directory for the Grails project you created in the last step.*
 
 [source, bash]
 ----


### PR DESCRIPTION
I've added a note on the need to call `grails list-profiles` from outside of the newly created Grails project for clarity.  

I like to go through the guides listed on the site from time to time as a refresher as I don't use Grails day-to-day, and always find myself confused when I run `grails list-profiles`  and receive the following error message:

```bash
| Error Command not found list-profiles
Did you mean: list-plugins or test or test-app?
```
The error occurs because profiles are really only needed when creating new Grails projects and can't be listed from within a Grails directory.  I feel that adding a note on this would help prevent new users from becoming confused if they see the error I've listed above.