### PR TITLE
Fix line shift for g:link fragment

### DIFF
--- a/src/main/docs/guide/gspLinks.adoc
+++ b/src/main/docs/guide/gspLinks.adoc
@@ -3,7 +3,7 @@ Let's take a look at one more common GSP tag: `<g:link>`
 [source,xml]
 .grails-app/views/home/index.gsp
 ----
-include::{sourceDir}/grails-app/views/home/index.gsp[indent=0,lines="34..36"]
+include::{sourceDir}/grails-app/views/home/index.gsp[indent=0,lines="33..35"]
 ----
 
 `<g:link>` renders an HTML `<a>` tag, but it has the advantage in that it allows you to specify your link target following Grails conventions, such as this example (using the `controller`, `action` and `id` attributes). `<g:link>` is also smart enough to follow our URL mappings, so if we change the URL mapping for `vehicle/show`, the `<g:link>` tag will still render the correct URL. There's many more attributes supported by `<g:link>` - see the http://docs.grails.org/latest/ref/Tags/link.html[Grails documentation] for more.


### PR DESCRIPTION
Current version of first grails app documentation has a glitch on the `7.4 GSP Tags Links` section. The code fragment lacks of the first line, and has a useless bottom line :

> 7.4 GSP Tags Links
> 
> Let’s take a look at one more common GSP tag: <g:link>
> grails-app/views/home/index.gsp
> 
>         ${vehicle.name} - ${vehicle.year} ${vehicle.make.name} ${vehicle.model.name}
>     </g:link>
> </li>
> 
> <g:link> renders an HTML <a> tag, but it has the advantage in that it allows you to specify your link target following Grails conventions, such as this example (using the controller, action and id attributes). <g:link> is also smart enough to follow our URL mappings, so if we change the URL mapping for vehicle/show, the <g:link> tag will still render the correct URL. There’s many more attributes supported by <g:link> - see the Grails documentation for more.
