### PR TITLE
Update databaseConsole.adoc

### DIFF
--- a/src/main/docs/guide/databaseConsole.adoc
+++ b/src/main/docs/guide/databaseConsole.adoc
@@ -1,6 +1,12 @@
-If you run the app again, you should see the same page as before. However, you can login to the DB Console and view your new database table.
+Additional setup to view the H2 Database Console.  Add the following to application.yml
+spring:
+  h2:
+    console:
+      enabled: true
 
-Browse to `http://localhost:8080/dbconsole` and login. The default username is `sa`, without a password. The default JDBC URL is: `jdbc:h2:mem:devDb;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE`
+If you run the app again, you should see the same page as before. However, you can login to the H2 Console and view your new database table.
+
+Browse to `http://localhost:8080/h2-console` and login. The default username is `sa`, without a password. The default JDBC URL is: `jdbc:h2:mem:devDb;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE`
 
 image::dbconsole.png[DB Console]
 


### PR DESCRIPTION
I found while trying to access DBConsole that with version 4.05 of Grails, it doesn't have that path any longer. The following link gives the detail of the process to fix, but I've updated/changed the document to reflect this (please change to make more sense if need be)