### PR TITLE
Corrects the URL for dbconsole

### DIFF
--- a/src/main/docs/guide/databaseConsole.adoc
+++ b/src/main/docs/guide/databaseConsole.adoc
@@ -1,6 +1,6 @@
 If you run the app again, you should see the same page as before. However, you can login to the DB Console and view your new database table.
 
-Browse to `http://localhost:8080/dbconsole` and login. The default username is `sa`, without a password. The default JDBC URL is: `jdbc:h2:mem:devDb;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE`
+Browse to `http://localhost:8080/h2-console` and login. The default username is `sa`, without a password. The default JDBC URL is: `jdbc:h2:mem:devDb;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE`
 
 image::dbconsole.png[DB Console]
 


### PR DESCRIPTION
H2 DbConsole is not found at 
http://localhost:8080/dbconsole any more but rather at http://localhost:8080/h2-console
Here is the reference https://github.com/grails/grails-core/issues/11232